### PR TITLE
Add RustChain Ergo Anchor to Bridges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
   - [CLI Utils](https://github.com/rosen-bridge/utils/tree/dev/packages/cli) – Command-line utilities for bridge operations. [`TS`?]
   - [Docker Deploy Guide](https://github.com/rosen-bridge/operation/blob/dev/docs/watcher/deploy-docker.md) – Guide for deploying bridge components using Docker.
 - [ErgoGravity Gateway Proxy](https://github.com/ErgoGravity/gateway-proxy) - Proxy component potentially related to cross-chain communication or bridging. *(Community, Context Needed)*
+- [RustChain Ergo Anchor](https://github.com/Scottcjn/Rustchain) – Proof of Antiquity blockchain that anchors miner attestation data into Ergo box registers (R4-R9). Rewards vintage hardware (PowerPC G4/G5, POWER8) for mining with time-aged multipliers. [`Python`] *(Community, Active)*
 
 ## 💼 Wallets <a id="wallets"></a>
 


### PR DESCRIPTION
## Summary
- Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Bridges section
- RustChain is a Proof of Antiquity blockchain that anchors miner attestation data into Ergo box registers (R4-R9)
- Rewards vintage hardware (PowerPC G4/G5, IBM POWER8) for mining with time-aged multipliers
- Uses zero-fee transactions on a private Ergo chain for on-chain anchoring
- Active project with 3 attestation nodes and 8+ active miners

## Details
RustChain uses Ergo's register system to store Blake2b256 commitment hashes of miner attestation data:
- **R4**: Commitment hash (32 bytes)
- **R5**: Miner count
- **R6**: Miner IDs
- **R7**: Device architectures
- **R8**: RustChain slot height
- **R9**: Timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)