### PR TITLE
Add RustChain - Proof-of-Antiquity blockchain with Ergo anchoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@
   - [Token Flight Bot](https://github.com/The-Last-Byte-Bar/Token-Flight-Bot) – Bot associated with the Token Flight protocol.
 - [Sigmanaut Mining Pool UI](https://github.com/marctheshark3/sigmanaut-mining-pool-ui) – Community-developed user interface for the Sigmanauts mining pool. [`JS/TS`] *(Community UI)*
 - [Ergo CYTI Miner](https://github.com/Telefragged/ergo-cyti-miner) – Specialized miner designed to mine NFTs using the CYTI (Choose Your Token ID) contract. [`Rust`] *(Tool, ErgoHack)*
+- [RustChain](https://github.com/Scottcjn/Rustchain) – Proof-of-Antiquity blockchain that anchors miner attestation data to Ergo via register-based transactions. Uses 6-point hardware fingerprinting (clock drift, cache timing, SIMD identity, thermal drift, instruction jitter, anti-emulation) to reward vintage hardware miners. [`Python`] *(Community)*
 
 ### 🧠 Smart Pooling <a id="smart-pooling"></a>
 


### PR DESCRIPTION
## Summary

Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Mining > Utilities & Tooling section.

RustChain is a Proof-of-Antiquity blockchain that **anchors miner attestation data directly to Ergo** via register-based transactions (R4-R9). It stores Blake2b256 commitment hashes of miner attestation data in Ergo box registers, creating an immutable cross-chain audit trail.

**Ergo integration specifics:**
- Anchors miner attestation commitments to Ergo boxes using registers R4-R9
- R4: Blake2b256 commitment hash, R5: miner count, R6: miner IDs, R7: device architectures, R8: slot height, R9: timestamp
- Uses Ergo's private chain with zero-fee transactions for anchoring
- `ergo_miner_anchor.py` module handles TX construction, signing, and broadcast via Ergo wallet API

**Other features:**
- 6-point hardware fingerprinting prevents VM spoofing
- Vintage hardware (PowerPC G4/G5) earns higher mining multipliers
- Ed25519 signatures, BIP39 wallets
- RIP-200 round-robin 1-CPU-1-Vote consensus

Placed in Mining > Utilities & Tooling, following the existing entry format with `[Python]` language tag and `(Community)` label.